### PR TITLE
Upgrade to Traefik 2.3

### DIFF
--- a/001-rbac.yaml
+++ b/001-rbac.yaml
@@ -104,8 +104,8 @@ spec:
   scope: Namespaced
 
 ---
-kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
 metadata:
   name: traefik-ingress-controller
 
@@ -122,8 +122,10 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - networking.k8s.io
     resources:
       - ingresses
+      - ingressclasses
     verbs:
       - get
       - list

--- a/005-deployment.yaml
+++ b/005-deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccountName: traefik-ingress-controller
       containers:
         - name: traefik
-          image: traefik:v2.2
+          image: traefik:v2.3
           args:
             - --api.dashboard=true
             - --accesslog

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cluster. This performs the following:
   and they will be created here on the host machine.
 - (optional) publish ports 80 and 443 to the host machine so that we can send
   external web traffic (http and https) to the cluster
-- the `--server-arg` arguments will pass `--no-deploy traefik` to k3s when the
+- the `--server-arg` arguments will pass `--disable traefik` to k3s when the
   cluster is created so that the default Traefik 1.7 ingress controller is not
   installed
 
@@ -60,7 +60,7 @@ $ k3d cluster create \
   --port "80:80@loadbalancer" \
   --port "443:443@loadbalancer" \
   --agents 2 \
-  --k3s-server-arg --no-deploy \
+  --k3s-server-arg --disable \
   --k3s-server-arg traefik
 
 $ export KUBECONFIG="$(k3d kubeconfig get sleighzy)"
@@ -71,7 +71,7 @@ $ kubectl cluster-info
 ## Install Traefik Kubernetes CRD Ingress Controller
 
 k3s ships with Traefik 1.7 by default so we need to install Traefik 2 separately
-using the manifests in this repository as the `--no-deploy traefik` arguments we
+using the manifests in this repository as the `--disable traefik` arguments we
 used mean that Traefik is not installed.
 
 Apply the manifests in order (prefixed by number) to install the secrets, k8s


### PR DESCRIPTION
Upgrade from Traefik 2.2 to 2.3.

- This introduces support for the new Kubernetes IngressClass type.
- Use "--disable" server args for K3s as the "--no-deploy" args were deprecated in v3.