### PR TITLE
Add default TLS Option for TLS 1.3

### DIFF
--- a/001-tls-options.yaml
+++ b/001-tls-options.yaml
@@ -1,0 +1,17 @@
+---
+# https://doc.traefik.io/traefik/https/tls/#tls-options
+# Set the minimum TLS version to 1.3.
+# This will pass the SSL Labs checks for the web site.
+# https://www.ssllabs.com/ssltest/
+# The "default" option is special and is used across all
+# namespaces if not overridden by an ingress route.
+# There must be only one with the name "default" otherwise
+# they will be dropped.
+apiVersion: traefik.containo.us/v1alpha1
+kind: TLSOption
+metadata:
+  name: default
+  namespace: default
+
+spec:
+  minVersion: VersionTLS13

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ secrets from the `./005-deployment.yaml` file. The later sections in this README
 file will cover the HTTPS integration in greater depth.
 
 - [001-rbac.yaml](./001-rbac.yaml) - CRDs and cluster roles
+- [001-tls-options.yaml](./001-tls-options.yaml) - this is optional, but
+  enforces by default that TLS 1.3 is to be used for secure connections
 - [002-middlewares.yaml](./002-middlewares.yaml) - this is optional, but is
   needed if wanting to secure the Traefik dashboard using Basic Authentication
 - [002-secrets.yaml](./002-secrets.yaml) - this is optional, but is needed if


### PR DESCRIPTION
The 001-tls-options.yaml manifest can be applied so that TLS 1.3
is used by default for ingresses for secure connections.

Note that the name "default" is special and that there must be only
one of these configured across all namespaces.

https://doc.traefik.io/traefik/https/tls/#tls-options