### PR TITLE
Add support for enabling the Kubernetes Ingress provider

### DIFF
--- a/005-deployment.yaml
+++ b/005-deployment.yaml
@@ -35,6 +35,7 @@ spec:
             - --entrypoints.web.address=:80
             - --entrypoints.websecure.address=:443
             - --providers.kubernetescrd
+            - --providers.kubernetesingress
             - --certificatesresolvers.godaddy.acme.email=me@mydomain.io
             - --certificatesresolvers.godaddy.acme.storage=/etc/traefik/certs/acme.json
             - --certificatesResolvers.godaddy.acme.dnsChallenge.provider=godaddy

--- a/100-whoami.yaml
+++ b/100-whoami.yaml
@@ -36,19 +36,3 @@ spec:
       port: 80
   selector:
     app: whoami
----
-apiVersion: traefik.containo.us/v1alpha1
-kind: IngressRoute
-metadata:
-  name: whoami
-  namespace: default
-
-spec:
-  entryPoints:
-    - web
-  routes:
-    - match: Host(`whoami.mydomain.io`)
-      kind: Rule
-      services:
-        - name: whoami
-          port: 80

--- a/200-whoami-ingressroute-tls.yaml
+++ b/200-whoami-ingressroute-tls.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: whoami-tls
+  namespace: default
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`whoami.mydomain.io`) && PathPrefix(`/tls`)
+      services:
+        - name: whoami
+          port: 80
+  tls:
+    certResolver: godaddy

--- a/200-whoami-ingressroute.yaml
+++ b/200-whoami-ingressroute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: whoami
+  namespace: default
+
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`whoami.mydomain.io`)
+      kind: Rule
+      services:
+        - name: whoami
+          port: 80

--- a/300-whoami-ingress.yaml
+++ b/300-whoami-ingress.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: whoami
+  namespace: default
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls.certresolver: godaddy
+
+spec:
+  rules:
+    - host: whoami.mydomain.io
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: whoami
+                port:
+                  number: 80

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ spec:
 Confirm that the service and ingress route have been created.
 
 ```sh
-$ kubectl get svc,ep,ingress,ingressroute -o wide
+$ kubectl get svc,ep,ingressroute -o wide
 NAME                 TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE     SELECTOR
 service/kubernetes   ClusterIP   10.43.0.1       <none>        443/TCP   2d19h   <none>
 service/whoami       ClusterIP   10.43.226.213   <none>        80/TCP    2d19h   app=whoami
@@ -416,3 +416,23 @@ X-Forwarded-Server: traefik-7c8b9b949f-cws5b
 X-Forwarded-User:
 X-Real-Ip: 10.42.1.6
 ```
+
+## Traefik 2.2 and Kubernetes Ingress
+
+Traefik
+[Kubernetes Ingress](https://doc.traefik.io/traefik/providers/kubernetes-ingress/)
+provider supports
+[Kubernete Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+objects for managing access to services.
+
+The `--providers.kubernetesingress` CLI parameter in the deployment manifest
+enables using this provider to configure Traefik. This provider be can run with
+the Kubernetes CRD one enabled as well, `--providers.kubernetescrd`, so that
+both options are supported.
+
+The [300-whoami-ingress.yaml](./300-whoami-ingress.yaml) manifest file can be
+applied instead of the
+[200-whoami-ingressroute.yaml](./200-whoami-ingressroute.yaml) file to use the
+Kubernetes Ingress to provide access to the whoami service. This example ingress
+also shows the use of the annotation support that was added in Traefik 2.2 for
+these objects for things such as the entry point and tls configuration.


### PR DESCRIPTION
The Kubernetes Ingress provider is also enabled so this can be used as well as the Kubernetes CRD one.

An example ingress is provided for the whoami service to show this in use.