### PR TITLE
Add AppArmor profile and run container as non-root user

### DIFF
--- a/004-service.yaml
+++ b/004-service.yaml
@@ -7,16 +7,23 @@ metadata:
 
 spec:
   externalTrafficPolicy: Cluster
+  # The targetPort entries are required as the Traefik container is listening on ports > 1024
+  # so that the container can be run as a non-root user and they can bind to these ports.
+  # Traefik is still accessed over 80 and 443 on the host, but the service routes the traffic
+  # to ports 8080 and 8443 on the container.
   ports:
     - protocol: TCP
       name: web
       port: 80
+      targetPort: 8080
     - protocol: TCP
       name: websecure
       port: 443
+      targetPort: 8443
     - protocol: TCP
       name: admin
       port: 8080
+      targetPort: 9080
   selector:
     app: traefik
   type: LoadBalancer

--- a/005-deployment.yaml
+++ b/005-deployment.yaml
@@ -23,8 +23,14 @@ spec:
     metadata:
       labels:
         app: traefik
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/traefik: runtime/default
     spec:
       serviceAccountName: traefik-ingress-controller
+      securityContext:
+        # Use nogroup (and needs nobody) for the acme.json file
+        # for storing TLS
+        fsGroup: 65534
       containers:
         - name: traefik
           image: traefik:v2.3
@@ -32,9 +38,9 @@ spec:
             - --api.dashboard=true
             - --ping=true
             - --accesslog
-            - --entrypoints.traefik.address=:8080
-            - --entrypoints.web.address=:80
-            - --entrypoints.websecure.address=:443
+            - --entrypoints.traefik.address=:9080
+            - --entrypoints.web.address=:8080
+            - --entrypoints.websecure.address=:8443
             - --providers.kubernetescrd
             - --providers.kubernetesingress
             - --certificatesresolvers.godaddy.acme.email=me@mydomain.io
@@ -46,11 +52,20 @@ spec:
             # - --certificatesresolvers.godaddy.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory
             - --log
             - --log.level=INFO
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            # Run the container as nobody:nogroup
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /ping
-              port: 8080
+              port: 9080
               scheme: HTTP
             initialDelaySeconds: 10
             periodSeconds: 10
@@ -60,12 +75,14 @@ spec:
               memory: '100Mi'
               cpu: '1000m'
           ports:
+            # The Traefik container is listening on ports > 1024 so the container
+            # can be run as a non-root user and they can bind to these ports.
             - name: web
-              containerPort: 80
-            - name: websecure
-              containerPort: 443
-            - name: admin
               containerPort: 8080
+            - name: websecure
+              containerPort: 8443
+            - name: admin
+              containerPort: 9080
           volumeMounts:
             - name: certificates
               mountPath: /etc/traefik/certs

--- a/100-whoami.yaml
+++ b/100-whoami.yaml
@@ -1,12 +1,11 @@
 ---
-kind: Deployment
 apiVersion: apps/v1
+kind: Deployment
 metadata:
   namespace: default
   name: whoami
   labels:
     app: whoami
-
 spec:
   replicas: 1
   selector:
@@ -16,15 +15,31 @@ spec:
     metadata:
       labels:
         app: whoami
+      annotations:
+        container.apparmor.security.beta.kubernetes.io/whoami: runtime/default
     spec:
       containers:
         - name: whoami
           image: containous/whoami
+          imagePullPolicy: Always
+          # Listen on port 8080 to run as non-root user
+          args:
+            - --port
+            - '8080'
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            # Run the container as nobody:nogroup
+            runAsUser: 65534
+            runAsGroup: 65534
+            capabilities:
+              drop:
+                - ALL
           livenessProbe:
             failureThreshold: 3
             httpGet:
               path: /health
-              port: 80
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -35,17 +50,19 @@ spec:
               cpu: '500m'
           ports:
             - name: web
-              containerPort: 80
+              containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: whoami
-
 spec:
   ports:
     - protocol: TCP
       name: web
       port: 80
+      # whoami is listening on 8080 from --port argument so that non-root user
+      # can run container as needs to bind to ports higher than 1024
+      targetPort: 8080
   selector:
     app: whoami

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ file will cover the HTTPS integration in greater depth.
 
 Traefik provides a number of dashboards for viewing your services, routes,
 middleware, etc. In the current deployment configuration this is not being
-exposed outside of the cluster. You can port forward `8080` (the admin port)
-from the docker host to the traefik service and then you can navigate to
+exposed outside of the cluster. You can port forward `8080` on the docker host
+to the traefik admin service and then you can navigate to
 <http://localhost:8080/dashboard/> in your browser to view the Traefik
 dashboard.
 
@@ -125,7 +125,7 @@ dashboard.
 for accessing the dashboard must contain a trailing slash.
 
 ```sh
-kubectl port-forward --address 0.0.0.0 service/traefik 8080:8080 -n kube-system
+kubectl port-forward --address 0.0.0.0 service/traefik 8080:admin -n kube-system
 ```
 
 ### Basic Authentication


### PR DESCRIPTION
The Traefik and whoami containers are run as non-root users, using nobody:nogroup in this deployment.
The containers listen on ports > 1024 so that this user can bind to the ports, traffic is still sent to
ports 80 and 443 on the host but the Kubernetes service will route this to ports 8080 and 8443 on the container.

The fsGroup is set to 65534 and the acme.json file gets created (or needs to be updated if already existing) to
the nobody:nogroup so that TLS certificates can continue to be written to it.

An AppArmor profile has been added to the deployment and all capabilities dropped.