### PR TITLE
Set externalTrafficPolicy to Local

### DIFF
--- a/004-service.yaml
+++ b/004-service.yaml
@@ -6,7 +6,6 @@ metadata:
   namespace: kube-system
 
 spec:
-  externalTrafficPolicy: Cluster
   # The targetPort entries are required as the Traefik container is listening on ports > 1024
   # so that the container can be run as a non-root user and they can bind to these ports.
   # Traefik is still accessed over 80 and 443 on the host, but the service routes the traffic
@@ -26,4 +25,8 @@ spec:
       targetPort: 9080
   selector:
     app: traefik
+  # Set externalTrafficPolicy to Local so that all external traffic intended for
+  # the Traefik pod goes directly to that local node. If the default of Cluster is
+  # used instead then the client source IP address is lost, and may hop between nodes.
+  externalTrafficPolicy: Local
   type: LoadBalancer

--- a/README.md
+++ b/README.md
@@ -277,12 +277,12 @@ Host: whoami.mydomain.io
 User-Agent: curl/7.58.0
 Accept: */*
 Accept-Encoding: gzip
-X-Forwarded-For: 10.42.1.6
+X-Forwarded-For: 210.53.22.215
 X-Forwarded-Host: whoami.mydomain.io
 X-Forwarded-Port: 80
 X-Forwarded-Proto: http
 X-Forwarded-Server: traefik-7c8b9b949f-cws5b
-X-Real-Ip: 10.42.1.6
+X-Real-Ip: 210.53.22.215
 ```
 
 ## HTTPS with LetsEncrypt
@@ -408,13 +408,13 @@ Accept-Encoding: gzip, deflate, br
 Accept-Language: en-US,en;q=0.5
 Cookie: _forward_auth=jRmJ5On5wAvIdKJ-B22_gFu0J9mMXnaxPQqUozvQYxw=|1584999044|
 Upgrade-Insecure-Requests: 1
-X-Forwarded-For: 10.42.1.6
+X-Forwarded-For: 210.53.22.215
 X-Forwarded-Host: whoami.mydomain.io
 X-Forwarded-Port: 443
 X-Forwarded-Proto: https
 X-Forwarded-Server: traefik-7c8b9b949f-cws5b
 X-Forwarded-User:
-X-Real-Ip: 10.42.1.6
+X-Real-Ip: 210.53.22.215
 ```
 
 ## Traefik 2.2 and Kubernetes Ingress


### PR DESCRIPTION
The externalTrafficPolicy setting determines whether or not external traffic
is routed directly to the local node running the pod, or can be routed pods
running on other nodes. Setting this to Local means that the external ip
of the load balancer is the node that it is deployed on, and that the
client source IP address is preserved. If this is set to Cluster (the default)
then the client source IP address is lost.

https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/