### PR TITLE
Upgrade to v1 versions of Kubernetes APIs

### DIFF
--- a/001-rbac.yaml
+++ b/001-rbac.yaml
@@ -1,12 +1,18 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutes.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: IngressRoute
     plural: ingressroutes
@@ -14,14 +20,20 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressroutetcps.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: IngressRouteTCP
     plural: ingressroutetcps
@@ -29,14 +41,20 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ingressrouteudps.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: IngressRouteUDP
     plural: ingressrouteudps
@@ -44,14 +62,20 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: middlewares.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: Middleware
     plural: middlewares
@@ -59,14 +83,20 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tlsoptions.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: TLSOption
     plural: tlsoptions
@@ -74,14 +104,20 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: tlsstores.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: TLSStore
     plural: tlsstores
@@ -89,14 +125,20 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: traefikservices.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: TraefikService
     plural: traefikservices
@@ -104,14 +146,20 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: serverstransports.traefik.containo.us
 
 spec:
   group: traefik.containo.us
-  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: false
+    - name: v1
+      served: true
+      storage: true
   names:
     kind: ServersTransport
     plural: serverstransports
@@ -119,7 +167,7 @@ spec:
   scope: Namespaced
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: traefik-ingress-controller
@@ -168,8 +216,8 @@ rules:
       - watch
 
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: traefik-ingress-controller
 


### PR DESCRIPTION
* update from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1
* update from rbac.authorization.k8s.io/v1beta1 to rbac.authorization.k8s.io/v1

The v1alpha1 version is present in the list of versions for upgrade purposes for any
objects currently stored against that version.