### PR TITLE
Add init container for cert permissions

### DIFF
--- a/005-deployment.yaml
+++ b/005-deployment.yaml
@@ -31,6 +31,13 @@ spec:
         # Use nogroup (and needs nobody) for the acme.json file
         # for storing TLS
         fsGroup: 65534
+      initContainers:
+        - name: volume-permissions
+          image: busybox:1.32
+          command: ['sh', '-c', 'chmod -Rv 600 /etc/traefik/certs/*']
+          volumeMounts:
+            - name: certificates
+              mountPath: /etc/traefik/certs
       containers:
         - name: traefik
           image: traefik:v2.4


### PR DESCRIPTION
Traefik will skip certificate resolvers if the certificates file permissions are more
open than 600 (r/w only for the user).
As per their Helm chart an init container can be used to set the permissions to 600
on the certificates file so that it is used. Failure to do so will mean that the default
insecure Traefik certificate is presented for requested domains and untrusted errors
are shown in the browser and for services attempting to connect.

See https://github.com/traefik/traefik-helm-chart/blob/401c8cdf690cbbc765a935c7279566a13b79a082/traefik/values.yaml#L22 for the
usage of this in the Helm chart.