### PR TITLE
Set allCrossNamespace configuration option to true

### DIFF
--- a/005-deployment.yaml
+++ b/005-deployment.yaml
@@ -56,6 +56,7 @@ spec:
             # - --entrypoints.web.http.redirections.entrypoint.to=:443
             # - --entrypoints.web.http.redirections.entrypoint.scheme=https
             - --providers.kubernetescrd
+            - --providers.kubernetescrd.allowCrossNamespace=true
             - --providers.kubernetesingress
             - --certificatesresolvers.godaddy.acme.email=me@mydomain.io
             - --certificatesresolvers.godaddy.acme.storage=/etc/traefik/certs/acme.json

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Routes], which is what the configuration in this repository is based on.
   - [Prerequisites for certificate generation]
   - [Route https traffic to the whoami service]
   - [Redirect HTTP traffic to HTTPS]
+- [Accessing Resources in Other Namespaces]
 - [Secure Headers Middleware]
 - [Traefik 2.2 and Kubernetes Ingress]
 
@@ -498,6 +499,16 @@ continuously be redirected by Traefik.
 ```yaml
 - --entrypoints.web.http.redirections.entrypoint.permanent=true
 ```
+
+## Accessing Resources in Other Namespaces
+
+In Traefik v2.4.10 a change was made so that by default it was not possible to
+reference resources in other namespaces. To enable this the Traefik
+`providers.kubernetescrd.allowCrossNamespace` configuration property needs to
+be set to a value of `true`. For example, a "global" middleware could be created
+within the same namespace as the Traefik deployment to provide secure headers in
+responses. The `allowCrossNamespace` value must be `true` for ingress routes in
+other Kubernetes namespaces to be able to use this middleware in their configuration.
 
 ## Secure Headers Middleware
 


### PR DESCRIPTION
The allowCrossNamespace configured option must be set to true for the Traefik CRD provider
so that resources can be accessed in other namespaces.

This was previously the default but was changed to false by default in Trafik 2.4.10